### PR TITLE
Add the ability to drag and drop scene files in Scene Assign

### DIFF
--- a/addons/MetroidvaniaSystem/Database/MapEditor.gd
+++ b/addons/MetroidvaniaSystem/Database/MapEditor.gd
@@ -26,6 +26,7 @@ func _ready() -> void:
 	get_current_sub_editor()._editor_enter()
 	MetSys.settings.theme_changed.connect(grid.queue_redraw)
 	map_overlay.mouse_entered.connect(map_overlay.grab_focus)
+	map_overlay.set_drag_forwarding(Callable(), _on_overlay_can_drop_data, _on_overlay_drop_data)
 
 func mode_pressed(button: BaseButton):
 	get_current_sub_editor()._editor_exit()
@@ -120,6 +121,12 @@ func is_unsaved() -> bool:
 func mark_saved():
 	saved_version = undo_redo.get_version()
 	update_name()
+
+func _on_overlay_can_drop_data(at_pos: Vector2, data) -> bool:
+	return get_current_sub_editor().can_drop_data(at_pos, data)
+
+func _on_overlay_drop_data(at_pos: Vector2, data) -> void:
+	get_current_sub_editor().drop_data(at_pos, data)
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:

--- a/addons/MetroidvaniaSystem/Database/MapEditor.tscn
+++ b/addons/MetroidvaniaSystem/Database/MapEditor.tscn
@@ -627,6 +627,21 @@ func create_scene_confirm() -> void:
 	EditorInterface.get_resource_filesystem().scan()
 	EditorInterface.open_scene_from_path(scene_path)
 	on_map_selected(scene_path)
+
+func can_drop_data(at_position: Vector2, data) -> bool:
+	if highlighted_room.is_empty():
+		return false
+	if data.get(\"type\", \"\") != \"files\" or len(data.files) != 1:
+		return false
+	
+	var file: String = data.files[0]
+	if not (file.ends_with(\".tscn\") or file.ends_with(\".scn\")) or not file.begins_with(MetSys.settings.map_root_folder):
+		return false
+	return true
+
+func drop_data(at_position: Vector2, data) -> void:
+	var file = data.files[0]
+	on_map_selected(file)
 "
 
 [sub_resource type="GDScript" id="GDScript_5yej3"]

--- a/addons/MetroidvaniaSystem/Database/SubEditor.gd
+++ b/addons/MetroidvaniaSystem/Database/SubEditor.gd
@@ -268,3 +268,11 @@ func _notification(what: int) -> void:
 		theme_cache.border_highlight = get_theme_color(&"border_highlight", &"MetSys")
 		theme_cache.cursor_color = get_theme_color(&"cursor_color", &"MetSys")
 		_update_theme()
+
+
+func can_drop_data(at_position: Vector2, data) -> bool:
+	return false
+
+
+func drop_data(at_position: Vector2, data) -> void:
+	pass


### PR DESCRIPTION
This PR adds the ability to drag files into the Scene Assign subeditor to easily assign scenes:


https://github.com/KoBeWi/Metroidvania-System/assets/74857873/af446599-9c67-45e9-a0e7-3e56931e2bb8


## Technical Details

- `SubEditor.gd`: Added virtual functions `can_drop_data` and `drop_data`.
- `MapEditor.tscn`
  - `OverlayLayer` built-in script (new)
    - Added built-in script for `MapView/OverlayLayer` control node to expose drag and drop functionality.
    - This script is necessary because AKAIK we cannot access Controls drag/drop control without implementing these virtual functions on the base node. It only acts as an interface to call the current subeditor's virtual functions
  - `SceneAssign` built-in script
    - Implement `can_drop_data` and `drop_data` to only accept file data with 1 file.


Some of the edited files are built-in scripts so I'll include the changes here for easier reviewing:

**`MapEditor.tscn::OverlayLayer`**
```gdscript
@tool
extends Control

const EDITOR_SCRIPT = preload("res://addons/MetroidvaniaSystem/Database/MapEditor.gd")
var editor: EDITOR_SCRIPT

func _ready():
	editor = owner

func _can_drop_data(at_position: Vector2, data) -> bool:
	return editor.get_current_sub_editor().can_drop_data(at_position, data)

func _drop_data(at_position: Vector2, data):
	editor.get_current_sub_editor().drop_data(at_position, data)
```

**`MapEditor.tscn::SceneAssign`**
```gdscript
# ...

func can_drop_data(at_position: Vector2, data) -> bool:
	return data.type == "files" and len(data.files) == 1 and not highlighted_room.is_empty()

func drop_data(at_position: Vector2, data) -> void:
	var file = data.files[0]
	on_map_selected(file)
```