### PR TITLE
fix: update MapViewer, not just MapEditor

### DIFF
--- a/addons/MetroidvaniaSystem/Database/Main.tscn
+++ b/addons/MetroidvaniaSystem/Database/Main.tscn
@@ -67,8 +67,9 @@ func reload_map():
 	%\"Map Editor\".current_map_view.update_all()
 	%\"Map Editor\".map_overlay.queue_redraw()
 	%\"Map Editor\".ghost_map.queue_redraw()
-	%\"Map Editor\".layers.clear()
-	%\"Map Editor\".current_map_view.update_all()
+	%\"Map Viewer\".layers.clear()
+	%\"Map Viewer\".current_map_view.update_all()
+	%\"Map Viewer\".map.queue_redraw()
 	%\"Map Viewer\".map_overlay.queue_redraw()
 "
 


### PR DESCRIPTION
Small fix to the reload-from-disk behavior - I think this is what was intended here.

I'm starting to swap out MetSys settings at runtime and in the editor ([here](https://github.com/russmatney/dino/commit/742f33bb326d128d8ceb3b3311edac6aab27f0e7)) - pretty fun!

Thanks so much for this plugin, it is excellent!