### PR TITLE
Fix a couple bugs in the Scrolling Rooms Transitions script

### DIFF
--- a/addons/MetroidvaniaSystem/Template/Scripts/Modules/ScrollingRoomTransitions.gd
+++ b/addons/MetroidvaniaSystem/Template/Scripts/Modules/ScrollingRoomTransitions.gd
@@ -59,9 +59,9 @@ func _on_room_changed(target_room: String):
 			if is_zero_approx(screen_delta.x) or is_zero_approx(screen_delta.y):
 				tween.tween_property(camera, ^"offset", Vector2(), SCROLL_TIME)
 			else:
-				var total := 1.0 / (screen_delta.x + screen_delta.y)
-				tween.tween_property(camera, ^"offset:x", 0.0, absf(screen_delta.x * total) * SCROLL_TIME)
-				tween.tween_property(camera, ^"offset:y", 0.0, absf(screen_delta.y * total) * SCROLL_TIME)
+				var total := 1.0 / (absf(screen_delta.x) + absf(screen_delta.y))
+				tween.tween_property(camera, ^"offset:x", 0.0, absf(screen_delta.x) * total * SCROLL_TIME)
+				tween.tween_property(camera, ^"offset:y", 0.0, absf(screen_delta.y) * total * SCROLL_TIME)
 			
 			await tween.finished
 			

--- a/addons/MetroidvaniaSystem/Template/Scripts/Modules/ScrollingRoomTransitions.gd
+++ b/addons/MetroidvaniaSystem/Template/Scripts/Modules/ScrollingRoomTransitions.gd
@@ -28,8 +28,7 @@ func _on_room_changed(target_room: String):
 		# This can happen when teleporting to another room.
 		return
 	
-	var camera: Camera2D = _player.get_node(^"Camera2D")
-	var original_player_position := _player.get_viewport().canvas_transform * _player.position
+	var camera: Camera2D = _player.get_viewport().get_camera_2d()
 	
 	var prev_room_instance := MetSys.get_current_room_instance()
 	if prev_room_instance:
@@ -61,8 +60,8 @@ func _on_room_changed(target_room: String):
 				tween.tween_property(camera, ^"offset", Vector2(), SCROLL_TIME)
 			else:
 				var total := 1.0 / (screen_delta.x + screen_delta.y)
-				tween.tween_property(camera, ^"offset:x", 0.0, screen_delta.x * total * SCROLL_TIME)
-				tween.tween_property(camera, ^"offset:y", 0.0, screen_delta.y * total * SCROLL_TIME)
+				tween.tween_property(camera, ^"offset:x", 0.0, absf(screen_delta.x * total) * SCROLL_TIME)
+				tween.tween_property(camera, ^"offset:y", 0.0, absf(screen_delta.y * total) * SCROLL_TIME)
 			
 			await tween.finished
 			


### PR DESCRIPTION
Hi, couple fixes for the scrolling transition script.

The camera 2d was found by name. This won't work if the camera has been renamed. Instead, pull the active camera from the player viewport's world. An unused variable was also removed.

Secondly, fix the transition timing. The screen_delta variable can be negative depending on the signs of the offsets. If this happens, either the separate x or y transition will end up with a negative time, and thus the tween skips that part of the animation. Adding an absf fixes this.