### PR TITLE
Fix scene assignment not refreshing the adjacent room previews

### DIFF
--- a/addons/MetroidvaniaSystem/Database/MapEditor.tscn
+++ b/addons/MetroidvaniaSystem/Database/MapEditor.tscn
@@ -595,16 +595,17 @@ func clear_scene(from: Array[Vector3i]) -> String:
 	if from.is_empty():
 		return \"\"
 	
-	var current_assigned: String = MetSys.map_data.get_cell_at(from[0]).assigned_scene
-	if current_assigned.is_empty():
+	var current_id: String = MetSys.map_data.get_cell_at(from[0]).id
+	if current_id.is_empty():
 		return \"\"
 	else:
-		MetSys.map_data.assigned_scenes.erase(current_assigned)
+		MetSys.map_data.assigned_scenes.erase(current_id)
 	
 	for p in from:
 		MetSys.map_data.get_cell_at(p).assigned_scene = \"\"
+		MetSys.map_data.get_cell_at(p).id = \"\"
 	
-	return current_assigned
+	return current_id
 
 func on_map_selected(path: String) -> void:
 	if assign_uid.button_pressed:
@@ -612,19 +613,22 @@ func on_map_selected(path: String) -> void:
 	else:
 		path = path.trim_prefix(MetSys.settings.map_root_folder)
 	
+	var id := MetSys.map_data.get_room_id(path)
 	var prev_scene := clear_scene(highlighted_room)
 	
 	var current_assigned: Array[Vector3i]
-	current_assigned.assign(MetSys.map_data.assigned_scenes.get(path, []))
+	current_assigned.assign(MetSys.map_data.assigned_scenes.get(id, []))
 	
 	if not current_assigned.is_empty():
 		var other_prev_scene := clear_scene(current_assigned)
 		undo_handle_scene_remove(current_assigned, other_prev_scene)
 	
-	MetSys.map_data.assigned_scenes[path] = []
+	MetSys.map_data.assigned_scenes[id] = []
 	for coords in highlighted_room:
-		MetSys.map_data.get_cell_at(coords).assigned_scene = path
-		MetSys.map_data.assigned_scenes[path].append(coords)
+		var cell_data := MetSys.map_data.get_cell_at(coords)
+		cell_data.assigned_scene = path
+		cell_data.id = id
+		MetSys.map_data.assigned_scenes[id].append(coords)
 	
 	undo_handle_scene_add(highlighted_room.duplicate(), prev_scene)
 	undo_end_with_redraw()


### PR DESCRIPTION
This is a fix for a couple of issues:

1) After assigning a room, the RoomInstance adjacent room previews did not work until the engine is restarted.
2) Removing an assigned scene that was set without uid mode messes up the UI until the engine is restarted.

Whilst I don't understand the code entirely, I have made this fix with a couple assumptions. These are:

1) CellData has an `assigned_scene` which can be either a .tscn file or a uid:// path. It also has an unsaved `id` which is always the uid:// path for simplicity - this is calculated from the `assigned_scene` variable when the map is loaded.
2) The map data `assigned_scenes` (plural) is a runtime cache of which rooms are assigned, keyed using the uid:// form

My guess is that this is something left over from after the uid:// system was introduced. The scene assignment tool only sets the `assigned_scene`, and doesn't set the corresponding `id` correctly. The room previews therefore don't work, but when the engine is restarted the `id` is recalculated. This change makes it calculate the `id` during assignment so the previews work immediately.

When you add or remove a scene, it was using the scene path directly in `assigned_scenes`, so if uid mode was turned off then it was using the tscn filename and getting rather confused. This change makes it use the uid for the `assigned_scenes` key.

Hopefully this is all correct. Thanks.
