### PR TITLE
Fixed silent set() error when encountering a non-typed Dictionary

### DIFF
--- a/addons/MetroidvaniaSystem/Scripts/SaveData.gd
+++ b/addons/MetroidvaniaSystem/Scripts/SaveData.gd
@@ -90,14 +90,15 @@ func set_data(data: Dictionary):
 	
 	for property_name in SIMPLE_STORABLE_PROPERTIES:
 		var property = get(property_name)
+		var data_property = data[property_name]
 		if property is Dictionary or property is Array:
-			property.assign(data[property_name])
+			property.assign(data_property)
 		else:
-			if(typeof(property) != typeof(data[property_name])):
+			if typeof(property) != typeof(data_property):
 				push_error("Wrong type of save property '%s'. Should be %s but provided %s. It failed to set." 
-				% [property_name, type_string(typeof(property)), type_string(typeof(data[property_name]))])
+				% [property_name, type_string(typeof(property)), type_string(typeof(data_property))])
 			
-			set(property_name, data[property_name]) 
+			set(property_name, data_property) 
 	
 	for override_string in data.cell_overrides:
 		var override: MetroidvaniaSystem.MapData.CellOverride = MetroidvaniaSystem.MapData.CellOverride.load_from_line(override_string)

--- a/addons/MetroidvaniaSystem/Scripts/SaveData.gd
+++ b/addons/MetroidvaniaSystem/Scripts/SaveData.gd
@@ -88,8 +88,16 @@ func set_data(data: Dictionary):
 	if data.is_empty():
 		return
 	
-	for property in SIMPLE_STORABLE_PROPERTIES:
-		get(property).assign(data[property])
+	for property_name in SIMPLE_STORABLE_PROPERTIES:
+		var property = get(property_name)
+		if property is Dictionary or property is Array:
+			property.assign(data[property_name])
+		else:
+			if(typeof(property) != typeof(data[property_name])):
+				push_error("Wrong type of save property '%s'. Should be %s but provided %s. It failed to set." 
+				% [property_name, type_string(typeof(property)), type_string(typeof(data[property_name]))])
+			
+			set(property_name, data[property_name]) 
 	
 	for override_string in data.cell_overrides:
 		var override: MetroidvaniaSystem.MapData.CellOverride = MetroidvaniaSystem.MapData.CellOverride.load_from_line(override_string)

--- a/addons/MetroidvaniaSystem/Scripts/SaveData.gd
+++ b/addons/MetroidvaniaSystem/Scripts/SaveData.gd
@@ -97,7 +97,7 @@ func set_data(data: Dictionary):
 			if typeof(property) != typeof(data_property):
 				push_error("Wrong type of save property '%s'. Should be %s but provided %s. It failed to set." 
 				% [property_name, type_string(typeof(property)), type_string(typeof(data_property))])
-			
+				continue
 			set(property_name, data_property) 
 	
 	for override_string in data.cell_overrides:

--- a/addons/MetroidvaniaSystem/Scripts/SaveData.gd
+++ b/addons/MetroidvaniaSystem/Scripts/SaveData.gd
@@ -89,7 +89,7 @@ func set_data(data: Dictionary):
 		return
 	
 	for property in SIMPLE_STORABLE_PROPERTIES:
-		set(property, data[property])
+		get(property).assign(data[property])
 	
 	for override_string in data.cell_overrides:
 		var override: MetroidvaniaSystem.MapData.CellOverride = MetroidvaniaSystem.MapData.CellOverride.load_from_line(override_string)


### PR DESCRIPTION
## Issue / Fix

In my game I keep map data in a json. When I load it the resulting structure is a generic non-typed dictionary.

<img width="517" height="319" alt="image" src="https://github.com/user-attachments/assets/df1c3b05-9747-44d2-a85b-fbc39ec53c20" />

HOWEVER, your dictionary is typed:

```gd
var stored_objects: Dictionary[String, bool]
```

When I call set_data, the set() fails silently and doesn't assign my stored_objects to yours. That is because set fails if there's a difference in types (Dictionary[String, bool] vs Dictionary). My change fixes this. While I recognize that there may be other solutions, what I did here is (hopefully) harmless to people using non-json setups and beneficial for those using json.

## Context as to set and assign

Set:
> Assigns value to the given property. If the property does not exist or the given value's type doesn't match, nothing happens.

Assign:
> Assigns elements of another array into the array. Resizes the array to match array. Performs **type conversions** if the array is typed.
